### PR TITLE
Support basic auth in WebhookFeignClient.

### DIFF
--- a/ft/src/ft/docker/dms-service.yaml
+++ b/ft/src/ft/docker/dms-service.yaml
@@ -24,6 +24,8 @@ server:
 dms-service:
   webhook:
     url: http://mockserver:1080/webhook
+    user: webhook-user
+    password: webhook-password
 
 storage:
   maven-group-prefix: corp.domain.dms

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/configuration/ValidationProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/configuration/ValidationProperties.kt
@@ -20,6 +20,5 @@ data class ValidationProperties(
         val exclude: Set<String> = emptySet(),
         val forbiddenTokens: Set<String> = emptySet(),
         val forbiddenPatterns: Set<Regex> = emptySet()
-
     )
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/configuration/WebhookConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/configuration/WebhookConfig.kt
@@ -1,0 +1,25 @@
+package org.octopusden.octopus.dms.configuration
+
+import feign.auth.BasicAuthRequestInterceptor
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.context.annotation.Bean
+
+class WebhookConfig(private val webhookProperties: WebhookProperties) {
+    @ConfigurationProperties("dms-service.webhook")
+    @ConditionalOnProperty(
+        prefix = "dms-service.webhook", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    )
+    @ConstructorBinding
+    data class WebhookProperties(
+        val url: String,
+        val user: String? = null,
+        val password: String? = null
+    )
+
+    @Bean
+    fun basicAuthRequestInterceptor() =
+        if (webhookProperties.user.isNullOrBlank() || webhookProperties.password.isNullOrBlank()) null
+        else BasicAuthRequestInterceptor(webhookProperties.user, webhookProperties.password)
+}

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/webhook/WebhookFeignClient.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/webhook/WebhookFeignClient.kt
@@ -1,12 +1,13 @@
 package org.octopusden.octopus.dms.webhook
 
+import org.octopusden.octopus.dms.configuration.WebhookConfig
 import org.octopusden.octopus.dms.event.Event
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.PostMapping
 
 @ConditionalOnProperty(prefix = "dms-service.webhook", name = ["enabled"], havingValue = "true", matchIfMissing = true)
-@FeignClient("webhook", url = "\${dms-service.webhook.url}")
+@FeignClient("webhook", url = "\${dms-service.webhook.url}", configuration = [WebhookConfig::class])
 interface WebhookFeignClient {
     @PostMapping
     fun post(event: Event)


### PR DESCRIPTION
New optional configuration properties are added: dms-service.webhook.user, dms-service.webhook.password.