### PR TITLE
Rename tab title 'Components' -> 'All'

### DIFF
--- a/server/src/frontend/components/ComponentGroupPane/presenter.jsx
+++ b/server/src/frontend/components/ComponentGroupPane/presenter.jsx
@@ -11,7 +11,7 @@ export default function componentGroupPane(props) {
     return <div className="component-group-pane-wrapper">
         <Tabs id="left-column-tabs" onChange={handleComponentGroupTabChange} selectedTabId={selectedComponentGroupTab}
               large={true} renderActiveTabPanelOnly={true}>
-            <Tab id="components" icon="application" title="Components" panel={<ComponentsTree/>}/>
+            <Tab id="components" icon="application" title="All" panel={<ComponentsTree/>}/>
             <Tab id="solutions" icon="applications" title="Solutions" panel={<SolutionTree/>}/>
             <Tab id="custom" icon="fork" title="Custom" panel={<GroupedComponentsTree getGroupedComponents={getCustomComponents} icon="fork"/>}/>
             <Tab id="clients" icon="dollar" title="Clients" panel={<GroupedComponentsTree getGroupedComponents={getClientsComponents} icon="dollar"/>}/>


### PR DESCRIPTION
Rename the first tab 'Components' to 'All'.
Assuming that all other tabs (Solutions, Custom, etc) are just filters that are applied to the whole set of components, it seems more natural to give the first tab a title 'All'