### PR TITLE
Implement file uploading retry in maven-dms-plugin

### DIFF
--- a/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/AbstractArtifactMojo.java
+++ b/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/AbstractArtifactMojo.java
@@ -5,8 +5,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import java.io.File;
 
 abstract public class AbstractArtifactMojo extends AbstractDmsMojo {
-
-
     @Parameter(property = "type", required = true)
     protected String type;
 
@@ -18,6 +16,9 @@ abstract public class AbstractArtifactMojo extends AbstractDmsMojo {
 
     @Parameter(property = "replace", defaultValue = "true")
     protected boolean replace;
+
+    @Parameter(property = "uploadAttempts", defaultValue = "3")
+    protected int uploadAttempts;
 
     @Parameter(property = "validationLog")
     protected File validationLog;

--- a/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/UploadArtifactsMojo.java
+++ b/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/UploadArtifactsMojo.java
@@ -49,6 +49,7 @@ public class UploadArtifactsMojo extends AbstractArtifactCoordinatesMojo {
                         dmsService.uploadArtifact(log,
                                 dmsServiceClient,
                                 targetArtifact.file,
+                                uploadAttempts,
                                 ComponentVersion.create(component, version),
                                 targetArtifact.type,
                                 targetArtifact.coordinates,

--- a/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/UploadFileMojo.java
+++ b/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/UploadFileMojo.java
@@ -36,6 +36,7 @@ public class UploadFileMojo extends AbstractArtifactMojo {
         dmsService.uploadArtifact(getLog(),
                 dmsServiceClient,
                 file,
+                uploadAttempts,
                 ComponentVersion.create(component, version),
                 artifactType,
                 new MavenArtifactCoordinatesDTO(new GavDTO(

--- a/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/ValidateArtifactsMojo.java
+++ b/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/ValidateArtifactsMojo.java
@@ -114,6 +114,7 @@ public class ValidateArtifactsMojo extends AbstractArtifactCoordinatesMojo {
                         dmsService.validateArtifact(log,
                                 dmsServiceClient,
                                 targetArtifact.file,
+                                uploadAttempts,
                                 ComponentVersion.create(component, version),
                                 targetArtifact.coordinates,
                                 validationToUse,

--- a/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/service/DMSService.java
+++ b/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/service/DMSService.java
@@ -10,9 +10,9 @@ import java.nio.file.Path;
 import org.apache.maven.plugin.logging.Log;
 
 public interface DMSService {
-    void validateArtifact(Log log, DmsServiceUploadingClient dmsServiceClient, File file, ComponentVersion componentVersion, ArtifactCoordinatesDTO coordinates, ValidationPropertiesDTO validationConfiguration, boolean failOnAlreadyExists, Path validationLog, boolean dryRun);
+    void validateArtifact(Log log, DmsServiceUploadingClient dmsServiceClient, File file, int uploadAttempts, ComponentVersion componentVersion, ArtifactCoordinatesDTO coordinates, ValidationPropertiesDTO validationConfiguration, boolean failOnAlreadyExists, Path validationLog, boolean dryRun);
 
-    void uploadArtifact(Log log, DmsServiceUploadingClient dmsServiceClient, File file, ComponentVersion componentVersion, ArtifactType type, ArtifactCoordinatesDTO coordinates, boolean failOnAlreadyExists, Path validationLog, boolean dryRun);
+    void uploadArtifact(Log log, DmsServiceUploadingClient dmsServiceClient, File file, int uploadAttempts, ComponentVersion componentVersion, ArtifactType type, ArtifactCoordinatesDTO coordinates, boolean failOnAlreadyExists, Path validationLog, boolean dryRun);
 
     void publish(Log log, DmsServiceUploadingClient dmsServiceClient, ComponentVersion componentVersion, boolean dryRun);
 }

--- a/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/service/DMSServiceImpl.java
+++ b/client/maven-dms-plugin/src/main/java/org/octopusden/octopus/dms/client/service/DMSServiceImpl.java
@@ -137,7 +137,8 @@ public class DMSServiceImpl implements DMSService {
             MavenArtifactCoordinatesDTO coordinates,
             boolean failOnAlreadyExists
     ) throws Exception {
-        Validate.isTrue(file.exists(), "File should exist at " + file.getAbsolutePath());
+        Validate.isTrue(file.isFile(), "File should exist at " + file.getAbsolutePath());
+        Validate.isTrue(uploadAttempts > 0, "uploadAttempts must be greater than zero");
         ArtifactDTO artifact = null;
         for(int i = 1; i <= uploadAttempts; i++) {
             try (InputStream inputStream = Files.newInputStream(file.toPath())) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a configurable uploadAttempts option (default: 3) to the Maven plugin to control retry attempts for artifact uploads.
  - Implemented automatic retry logic for artifact uploads and validation flows, improving reliability in transient failure scenarios.
  - Consistent behavior maintained for dry-run and existing artifacts; retries occur with brief delays between attempts.
  - Users can adjust uploadAttempts in plugin configuration to tailor resilience to their environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->