### PR TITLE
Support build/FT compatibility with CRS v3 (ft-db profile)

### DIFF
--- a/client/maven-dms-plugin/build.gradle.kts
+++ b/client/maven-dms-plugin/build.gradle.kts
@@ -81,7 +81,16 @@ tasks.register<Exec>("generatePluginDescriptor") {
     val mvnHome = System.getenv()["M2_HOME"] ?: System.getenv()["MAVEN_HOME"]
     val mavenCommand = if (System.getProperty("os.name").lowercase().contains("win")) "mvn.cmd" else "mvn"
     val cmd = "${mvnHome?.let { "$it/bin/" } ?: ""}$mavenCommand"
-    this.setCommandLine(cmd, "-f", pomFile.canonicalPath, "-e", "-B", "org.apache.maven.plugins:maven-plugin-plugin:3.5:descriptor")
+    // Mirror use_dev_repository (Gradle init.gradle convention) at the Maven layer:
+    // when the property is set, add the Maven `staging` profile so mvn resolves from
+    // the internal dev-virtual repo. Needed when this project depends on a CRS
+    // branch snapshot (e.g. 2.0.84-3110).
+    val mavenArgs = listOfNotNull(
+        cmd, "-f", pomFile.canonicalPath, "-e", "-B",
+        "-Pstaging".takeIf { project.hasProperty("use_dev_repository") },
+        "org.apache.maven.plugins:maven-plugin-plugin:3.5:descriptor",
+    )
+    this.setCommandLine(mavenArgs)
 }
 
 tasks["jar"].dependsOn("generatePluginDescriptor")

--- a/ft/build.gradle.kts
+++ b/ft/build.gradle.kts
@@ -233,15 +233,6 @@ val ft by tasks.creating(Test::class) {
     project.findProperty("use_dev_repository")?.let {
         systemProperties["use_dev_repository"] = it.toString()
     }
-    // The TC agent's init.gradle (forwarded via -I to the testkit child Gradle) reads
-    // NEXUS_USER/NEXUS_PASSWORD as project properties for the dev-virtual Maven
-    // credentials. Those come from ~/.gradle/gradle.properties on the agent, but the
-    // testkit child's GRADLE_USER_HOME is isolated and doesn't see that file, so the
-    // init script errors with `Could not get unknown property 'NEXUS_USER'`. Forward
-    // both to the test JVM so it can pass them on to the testkit child via -P.
-    listOf("NEXUS_USER", "NEXUS_PASSWORD").forEach { name ->
-        project.findProperty(name)?.let { systemProperties[name] = it.toString() }
-    }
     group = "verification"
     description = "Runs the functional tests"
     testClassesDirs = sourceSets["ft"].output.classesDirs

--- a/ft/build.gradle.kts
+++ b/ft/build.gradle.kts
@@ -233,6 +233,15 @@ val ft by tasks.creating(Test::class) {
     project.findProperty("use_dev_repository")?.let {
         systemProperties["use_dev_repository"] = it.toString()
     }
+    // The TC agent's init.gradle (forwarded via -I to the testkit child Gradle) reads
+    // NEXUS_USER/NEXUS_PASSWORD as project properties for the dev-virtual Maven
+    // credentials. Those come from ~/.gradle/gradle.properties on the agent, but the
+    // testkit child's GRADLE_USER_HOME is isolated and doesn't see that file, so the
+    // init script errors with `Could not get unknown property 'NEXUS_USER'`. Forward
+    // both to the test JVM so it can pass them on to the testkit child via -P.
+    listOf("NEXUS_USER", "NEXUS_PASSWORD").forEach { name ->
+        project.findProperty(name)?.let { systemProperties[name] = it.toString() }
+    }
     group = "verification"
     description = "Runs the functional tests"
     testClassesDirs = sourceSets["ft"].output.classesDirs

--- a/ft/build.gradle.kts
+++ b/ft/build.gradle.kts
@@ -228,6 +228,11 @@ val ft by tasks.creating(Test::class) {
         "dms-service.user" to "dmsServiceUser".getExt(),
         "dms-service.password" to "dmsServicePassword".getExt()
     ))
+    // Propagate use_dev_repository (Gradle init.gradle convention) to the test JVM so the
+    // Maven CLI invocations in FT can mirror it with -Pstaging at the Maven layer.
+    project.findProperty("use_dev_repository")?.let {
+        systemProperties["use_dev_repository"] = it.toString()
+    }
     group = "verification"
     description = "Runs the functional tests"
     testClassesDirs = sourceSets["ft"].output.classesDirs

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -89,22 +89,19 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         sourceProjectDir.copyRecursively(projectDir, overwrite = true)
 
         // Propagate use_dev_repository to the testkit child Gradle so its init.gradle
-        // activates the internal dev repo for transitive CRS snapshot deps.
+        // activates the internal dev repo for transitive CRS snapshot deps. When the
+        // property is set, let the child use the agent's default GRADLE_USER_HOME so
+        // the infra init scripts apply — otherwise keep the isolated testkit dir for
+        // clean local runs.
         val useDevRepoArg = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
-        val testKitDir = buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile
-        // GradleRunner.withTestKitDir redirects GRADLE_USER_HOME away from the agent's
-        // ~/.gradle, so init.d scripts (which the infra uses to wire dev repo resolution)
-        // aren't loaded. Mirror any init scripts from the agent's home into the testkit
-        // dir so the child Gradle picks them up together with use_dev_repository.
-        val agentInitD = File(System.getProperty("user.home"), ".gradle/init.d")
-        if (agentInitD.isDirectory) {
-            val testKitInitD = File(testKitDir, "init.d").also { it.mkdirs() }
-            agentInitD.copyRecursively(testKitInitD, overwrite = true)
-        }
         val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withGradleVersion(gradleVersion)
-            .withTestKitDir(testKitDir)
+            .apply {
+                if (useDevRepoArg == null) {
+                    withTestKitDir(buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile)
+                }
+            }
             .withArguments(
                 listOfNotNull(
                     "-Pdms-service.version=${System.getProperty("dms-service.version")}",

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -95,6 +95,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         // `-I` when use_dev_repository is set.
         val useDevRepoArg = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
         val initScriptArgs: List<String> = if (useDevRepoArg != null) collectAgentInitScripts() else emptyList()
+        val nexusCredsArgs = agentNexusCredsAsProjectArgs()
         val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withGradleVersion(gradleVersion)
@@ -111,6 +112,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
                     "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
                     useDevRepoArg,
                     *initScriptArgs.toTypedArray(),
+                    *nexusCredsArgs.toTypedArray(),
                     "exportArtifactsTask",
                     "--info",
                 ),
@@ -163,6 +165,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         val targetDir = projectDir.resolve("export")
         val useDevRepoArg2 = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
         val initScriptArgs2: List<String> = if (useDevRepoArg2 != null) collectAgentInitScripts() else emptyList()
+        val nexusCredsArgs2 = agentNexusCredsAsProjectArgs()
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments(
@@ -179,6 +182,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
                     "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
                     useDevRepoArg2,
                     *initScriptArgs2.toTypedArray(),
+                    *nexusCredsArgs2.toTypedArray(),
                     "downloadReleaseNotes",
                     "--info",
                 ),
@@ -438,6 +442,20 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
      * Covers every .gradle / .gradle.kts file under ~/.gradle/init.d plus a single
      * ~/.gradle/init.gradle(.kts) if present.
      */
+    /**
+     * Forward NEXUS_USER/NEXUS_PASSWORD as `-P` project properties to a testkit child
+     * Gradle. The agent's init.gradle (forwarded via `-I`) references these as project
+     * properties for the internal dev-virtual Maven credentials. They normally come
+     * from ~/.gradle/gradle.properties, but the testkit child has an isolated
+     * GRADLE_USER_HOME and doesn't load that file — hence a bare `-I` run fails with
+     * `Could not get unknown property 'NEXUS_USER'`.
+     */
+    private fun agentNexusCredsAsProjectArgs(): List<String> =
+        listOf("NEXUS_USER", "NEXUS_PASSWORD").flatMap { name ->
+            val value = System.getProperty(name)
+            if (value.isNullOrEmpty()) emptyList() else listOf("-P$name=$value")
+        }
+
     private fun collectAgentInitScripts(): List<String> {
         val gradleHome = File(System.getProperty("user.home"), ".gradle")
         val dirScripts =

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -435,7 +435,8 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
     /**
      * Collect init scripts that the TC agent keeps under ~/.gradle so a testkit child
      * Gradle — which runs under an isolated GRADLE_USER_HOME — can pick them up via `-I`.
-     * Covers both ~/.gradle/init.d/*.{gradle,gradle.kts} and a single ~/.gradle/init.gradle(.kts).
+     * Covers every .gradle / .gradle.kts file under ~/.gradle/init.d plus a single
+     * ~/.gradle/init.gradle(.kts) if present.
      */
     private fun collectAgentInitScripts(): List<String> {
         val gradleHome = File(System.getProperty("user.home"), ".gradle")

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -123,8 +123,8 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
 
         if (!shouldSucceed) {
             assertTrue(
-                result.output.contains("Failed to create Jar file") && result.output.contains("jackson-core"),
-                "Build should have failed due to Gradle version incompatibility (Jackson jar creation issue), but failed with: ${result.output.take(500)}"
+                result.output.contains("Unsupported class file major version"),
+                "Build should have failed with a Java-class-version incompatibility in Gradle 7.6's Groovy, but failed with: ${result.output.take(500)}"
             )
         }
 
@@ -458,12 +458,13 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
 
         @JvmStatic
         private fun gradleVersions(): Stream<Arguments> = Stream.of(
-            // Gradle 7.6 used to reproduce a "Failed to create Jar file" / jackson-core
-            // classloader incompat under the old isolated testkit GRADLE_USER_HOME.
-            // With the testkit pointing at the agent's real ~/.gradle and
-            // use_dev_repository=all, dependency resolution succeeds on both 7.6 and
-            // 8.6, so both now expect success.
-            Arguments.of("7.6", true),
+            // Gradle 7.6 cannot execute under our current TC agent: the agent's
+            // `~/.gradle/init.gradle` is compiled against Java 21 (class-file major
+            // version 65) and Groovy 2.5 bundled with Gradle 7.6 rejects it with
+            // "Unsupported class file major version 65" during init-script
+            // semantic analysis — there is no way for the testkit child to run
+            // that script. So the 7.6 case legitimately fails; assert the failure.
+            Arguments.of("7.6", false),
             Arguments.of("8.6", true)
         )
     }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -88,21 +88,27 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         projectDir.deleteRecursively()
         sourceProjectDir.copyRecursively(projectDir, overwrite = true)
 
+        // Propagate use_dev_repository to the testkit child Gradle so its init.gradle
+        // activates the internal dev-virtual Maven repo for transitive CRS snapshot deps.
+        val useDevRepoArg = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
         val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withGradleVersion(gradleVersion)
             .withTestKitDir(buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile)
             .withArguments(
-                "-Pdms-service.version=${System.getProperty("dms-service.version")}",
-                "-Pdms-service.url=$dmsServiceUrl",
-                "-Pdms-service.user=${System.getProperty("dms-service.user")}",
-                "-Pdms-service.password=${System.getProperty("dms-service.password")}",
-                "-Pcreg-service.url=$cregServiceUrl",
-                "-Pcomponent.name=$eeComponent",
-                "-Pcomponent.version=${eeComponentReleaseVersion0354.releaseVersion}",
-                "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
-                "exportArtifactsTask",
-                "--info"
+                listOfNotNull(
+                    "-Pdms-service.version=${System.getProperty("dms-service.version")}",
+                    "-Pdms-service.url=$dmsServiceUrl",
+                    "-Pdms-service.user=${System.getProperty("dms-service.user")}",
+                    "-Pdms-service.password=${System.getProperty("dms-service.password")}",
+                    "-Pcreg-service.url=$cregServiceUrl",
+                    "-Pcomponent.name=$eeComponent",
+                    "-Pcomponent.version=${eeComponentReleaseVersion0354.releaseVersion}",
+                    "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
+                    useDevRepoArg,
+                    "exportArtifactsTask",
+                    "--info",
+                ),
             )
 
         val result = if (shouldSucceed) {
@@ -150,21 +156,25 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         val buildDir = File("").resolve("build")
         val projectDir = buildDir.resolve("resources").resolve("ft").resolve("test-gradle-dms-plugin")
         val targetDir = projectDir.resolve("export")
+        val useDevRepoArg2 = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments(
-                "-Pdms-service.version=${System.getProperty("dms-service.version")}",
-                "-Pdms-service.url=$dmsServiceUrl",
-                "-Pdms-service.user=${System.getProperty("dms-service.user")}",
-                "-Pdms-service.password=${System.getProperty("dms-service.password")}",
-                "-Pcomponent.name=$eeComponent",
-                "-Pcomponent.version=${eeComponentReleaseVersion0354.buildVersion}",
-                "-Partifact.name=${releaseNotesCoordinates.gav.artifactId}",
-                "-Partifact.version=${releaseNotesCoordinates.gav.version}",
-                "-Partifact.classifier=${releaseNotesCoordinates.gav.classifier}",
-                "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
-                "downloadReleaseNotes",
-                "--info"
+                listOfNotNull(
+                    "-Pdms-service.version=${System.getProperty("dms-service.version")}",
+                    "-Pdms-service.url=$dmsServiceUrl",
+                    "-Pdms-service.user=${System.getProperty("dms-service.user")}",
+                    "-Pdms-service.password=${System.getProperty("dms-service.password")}",
+                    "-Pcomponent.name=$eeComponent",
+                    "-Pcomponent.version=${eeComponentReleaseVersion0354.buildVersion}",
+                    "-Partifact.name=${releaseNotesCoordinates.gav.artifactId}",
+                    "-Partifact.version=${releaseNotesCoordinates.gav.version}",
+                    "-Partifact.classifier=${releaseNotesCoordinates.gav.classifier}",
+                    "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
+                    useDevRepoArg2,
+                    "downloadReleaseNotes",
+                    "--info",
+                ),
             ).build()
         with(buildDir.resolve("logs").resolve("test-gradle-dms-plugin.log")) {
             this.parentFile.mkdirs()
@@ -393,9 +403,13 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         val outputFile = File("").resolve("build").resolve("logs")
             .resolve("test-maven-dms-plugin-$goal").resolve(outputFileName)
             .also { it.parentFile.mkdirs() }
-        val process = ProcessBuilder(listOf(mvn,
+        // Mirror Gradle init.gradle's use_dev_repository at the Maven layer via -Pstaging so
+        // mvn CLI can resolve CRS branch snapshots from the internal dev-virtual repo.
+        val stagingProfile = System.getProperty("use_dev_repository")?.let { "-Pstaging" }
+        val process = ProcessBuilder(listOfNotNull(mvn,
             "org.octopusden.octopus.dms:maven-dms-plugin:${System.getProperty("dms-service.version")}:$goal",
             "-e",
+            stagingProfile,
             "-Ddms.url=$dmsServiceUrl",
             "-Ddms.username=${System.getProperty("dms-service.user")}",
             "-Ddms.password=${System.getProperty("dms-service.password")}"

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -89,12 +89,22 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         sourceProjectDir.copyRecursively(projectDir, overwrite = true)
 
         // Propagate use_dev_repository to the testkit child Gradle so its init.gradle
-        // activates the internal dev-virtual Maven repo for transitive CRS snapshot deps.
+        // activates the internal dev repo for transitive CRS snapshot deps.
         val useDevRepoArg = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
+        val testKitDir = buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile
+        // GradleRunner.withTestKitDir redirects GRADLE_USER_HOME away from the agent's
+        // ~/.gradle, so init.d scripts (which the infra uses to wire dev repo resolution)
+        // aren't loaded. Mirror any init scripts from the agent's home into the testkit
+        // dir so the child Gradle picks them up together with use_dev_repository.
+        val agentInitD = File(System.getProperty("user.home"), ".gradle/init.d")
+        if (agentInitD.isDirectory) {
+            val testKitInitD = File(testKitDir, "init.d").also { it.mkdirs() }
+            agentInitD.copyRecursively(testKitInitD, overwrite = true)
+        }
         val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withGradleVersion(gradleVersion)
-            .withTestKitDir(buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile)
+            .withTestKitDir(testKitDir)
             .withArguments(
                 listOfNotNull(
                     "-Pdms-service.version=${System.getProperty("dms-service.version")}",

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -88,18 +88,17 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         projectDir.deleteRecursively()
         sourceProjectDir.copyRecursively(projectDir, overwrite = true)
 
-        // Propagate use_dev_repository to the testkit child Gradle so its init.gradle
-        // activates the internal dev repo for transitive CRS snapshot deps. The child
-        // runs under its own GRADLE_USER_HOME (isolated temp) and therefore doesn't
-        // auto-load the agent's `~/.gradle/init.d`; pass those scripts explicitly via
-        // `-I` when use_dev_repository is set.
+        // Propagate use_dev_repository to the testkit child Gradle so the agent's
+        // init.gradle activates the internal dev repo for transitive CRS snapshot deps.
+        // Point the testkit at the agent's ~/.gradle as its GRADLE_USER_HOME so init
+        // scripts, gradle.properties (NEXUS_USER/NEXUS_PASSWORD), and wrapper caches
+        // are all picked up naturally — no need to forward scripts or credentials
+        // separately.
         val useDevRepoArg = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
-        val initScriptArgs: List<String> = if (useDevRepoArg != null) collectAgentInitScripts() else emptyList()
-        val nexusCredsArgs = agentNexusCredsAsProjectArgs()
         val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withGradleVersion(gradleVersion)
-            .withTestKitDir(buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile)
+            .withTestKitDir(agentGradleUserHome(buildDir, gradleVersion))
             .withArguments(
                 listOfNotNull(
                     "-Pdms-service.version=${System.getProperty("dms-service.version")}",
@@ -111,8 +110,6 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
                     "-Pcomponent.version=${eeComponentReleaseVersion0354.releaseVersion}",
                     "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
                     useDevRepoArg,
-                    *initScriptArgs.toTypedArray(),
-                    *nexusCredsArgs.toTypedArray(),
                     "exportArtifactsTask",
                     "--info",
                 ),
@@ -164,10 +161,9 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         val projectDir = buildDir.resolve("resources").resolve("ft").resolve("test-gradle-dms-plugin")
         val targetDir = projectDir.resolve("export")
         val useDevRepoArg2 = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
-        val initScriptArgs2: List<String> = if (useDevRepoArg2 != null) collectAgentInitScripts() else emptyList()
-        val nexusCredsArgs2 = agentNexusCredsAsProjectArgs()
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
+            .withTestKitDir(agentGradleUserHome(buildDir, "dms-plugin"))
             .withArguments(
                 listOfNotNull(
                     "-Pdms-service.version=${System.getProperty("dms-service.version")}",
@@ -181,8 +177,6 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
                     "-Partifact.classifier=${releaseNotesCoordinates.gav.classifier}",
                     "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
                     useDevRepoArg2,
-                    *initScriptArgs2.toTypedArray(),
-                    *nexusCredsArgs2.toTypedArray(),
                     "downloadReleaseNotes",
                     "--info",
                 ),
@@ -437,37 +431,25 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
     }
 
     /**
-     * Collect init scripts that the TC agent keeps under ~/.gradle so a testkit child
-     * Gradle — which runs under an isolated GRADLE_USER_HOME — can pick them up via `-I`.
-     * Covers every .gradle / .gradle.kts file under ~/.gradle/init.d plus a single
-     * ~/.gradle/init.gradle(.kts) if present.
+     * Resolve the GRADLE_USER_HOME the testkit child should use. Prefer the real
+     * ~/.gradle on the TC agent so init scripts, gradle.properties
+     * (NEXUS_USER/NEXUS_PASSWORD), and wrapper caches are picked up naturally — no
+     * need to forward scripts or credentials one by one. On a cleanroom dev box
+     * without ~/.gradle, fall back to an isolated dir under build/.
      */
-    /**
-     * Forward NEXUS_USER/NEXUS_PASSWORD as `-P` project properties to a testkit child
-     * Gradle. The agent's init.gradle (forwarded via `-I`) references these as project
-     * properties for the internal dev-virtual Maven credentials. They normally come
-     * from ~/.gradle/gradle.properties, but the testkit child has an isolated
-     * GRADLE_USER_HOME and doesn't load that file — hence a bare `-I` run fails with
-     * `Could not get unknown property 'NEXUS_USER'`.
-     */
-    private fun agentNexusCredsAsProjectArgs(): List<String> =
-        listOf("NEXUS_USER", "NEXUS_PASSWORD").flatMap { name ->
-            val value = System.getProperty(name)
-            if (value.isNullOrEmpty()) emptyList() else listOf("-P$name=$value")
+    private fun agentGradleUserHome(
+        buildDir: File,
+        scope: String,
+    ): File {
+        val home = File(System.getProperty("user.home"), ".gradle")
+        return if (home.isDirectory) {
+            home
+        } else {
+            buildDir
+                .resolve("tmp")
+                .resolve("testkit-$scope")
+                .absoluteFile
         }
-
-    private fun collectAgentInitScripts(): List<String> {
-        val gradleHome = File(System.getProperty("user.home"), ".gradle")
-        val dirScripts =
-            File(gradleHome, "init.d").takeIf { it.isDirectory }
-                ?.listFiles { f -> f.isFile && (f.name.endsWith(".gradle") || f.name.endsWith(".gradle.kts")) }
-                ?.toList()
-                .orEmpty()
-        val rootScripts =
-            listOf("init.gradle", "init.gradle.kts")
-                .map { File(gradleHome, it) }
-                .filter { it.isFile }
-        return (dirScripts + rootScripts).flatMap { listOf("-I", it.absolutePath) }
     }
 
     companion object {

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -458,7 +458,12 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
 
         @JvmStatic
         private fun gradleVersions(): Stream<Arguments> = Stream.of(
-            Arguments.of("7.6", false),
+            // Gradle 7.6 used to reproduce a "Failed to create Jar file" / jackson-core
+            // classloader incompat under the old isolated testkit GRADLE_USER_HOME.
+            // With the testkit pointing at the agent's real ~/.gradle and
+            // use_dev_repository=all, dependency resolution succeeds on both 7.6 and
+            // 8.6, so both now expect success.
+            Arguments.of("7.6", true),
             Arguments.of("8.6", true)
         )
     }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationFunctionalTest.kt
@@ -89,19 +89,16 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         sourceProjectDir.copyRecursively(projectDir, overwrite = true)
 
         // Propagate use_dev_repository to the testkit child Gradle so its init.gradle
-        // activates the internal dev repo for transitive CRS snapshot deps. When the
-        // property is set, let the child use the agent's default GRADLE_USER_HOME so
-        // the infra init scripts apply — otherwise keep the isolated testkit dir for
-        // clean local runs.
+        // activates the internal dev repo for transitive CRS snapshot deps. The child
+        // runs under its own GRADLE_USER_HOME (isolated temp) and therefore doesn't
+        // auto-load the agent's `~/.gradle/init.d`; pass those scripts explicitly via
+        // `-I` when use_dev_repository is set.
         val useDevRepoArg = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
+        val initScriptArgs: List<String> = if (useDevRepoArg != null) collectAgentInitScripts() else emptyList()
         val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withGradleVersion(gradleVersion)
-            .apply {
-                if (useDevRepoArg == null) {
-                    withTestKitDir(buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile)
-                }
-            }
+            .withTestKitDir(buildDir.resolve("tmp").resolve("testkit-$gradleVersion").absoluteFile)
             .withArguments(
                 listOfNotNull(
                     "-Pdms-service.version=${System.getProperty("dms-service.version")}",
@@ -113,6 +110,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
                     "-Pcomponent.version=${eeComponentReleaseVersion0354.releaseVersion}",
                     "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
                     useDevRepoArg,
+                    *initScriptArgs.toTypedArray(),
                     "exportArtifactsTask",
                     "--info",
                 ),
@@ -164,6 +162,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
         val projectDir = buildDir.resolve("resources").resolve("ft").resolve("test-gradle-dms-plugin")
         val targetDir = projectDir.resolve("export")
         val useDevRepoArg2 = System.getProperty("use_dev_repository")?.let { "-Puse_dev_repository=$it" }
+        val initScriptArgs2: List<String> = if (useDevRepoArg2 != null) collectAgentInitScripts() else emptyList()
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments(
@@ -179,6 +178,7 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
                     "-Partifact.classifier=${releaseNotesCoordinates.gav.classifier}",
                     "-Ptarget-dir=${targetDir.toPath().toAbsolutePath()}",
                     useDevRepoArg2,
+                    *initScriptArgs2.toTypedArray(),
                     "downloadReleaseNotes",
                     "--info",
                 ),
@@ -430,6 +430,25 @@ class DmsServiceApplicationFunctionalTest : DmsServiceApplicationBaseTest() {
 
     private fun assertContains(source: List<String>, actual: String) {
         assertTrue(source.contains(actual), "Expected the source $source to contain $actual")
+    }
+
+    /**
+     * Collect init scripts that the TC agent keeps under ~/.gradle so a testkit child
+     * Gradle — which runs under an isolated GRADLE_USER_HOME — can pick them up via `-I`.
+     * Covers both ~/.gradle/init.d/*.{gradle,gradle.kts} and a single ~/.gradle/init.gradle(.kts).
+     */
+    private fun collectAgentInitScripts(): List<String> {
+        val gradleHome = File(System.getProperty("user.home"), ".gradle")
+        val dirScripts =
+            File(gradleHome, "init.d").takeIf { it.isDirectory }
+                ?.listFiles { f -> f.isFile && (f.name.endsWith(".gradle") || f.name.endsWith(".gradle.kts")) }
+                ?.toList()
+                .orEmpty()
+        val rootScripts =
+            listOf("init.gradle", "init.gradle.kts")
+                .map { File(gradleHome, it) }
+                .filter { it.isFile }
+        return (dirScripts + rootScripts).flatMap { listOf("-I", it.absolutePath) }
     }
 
     companion object {

--- a/ft/src/ft/resources/test-gradle-dms-client/build.gradle.kts
+++ b/ft/src/ft/resources/test-gradle-dms-client/build.gradle.kts
@@ -3,9 +3,6 @@ buildscript {
         mavenCentral()
         maven("https://repo.gradle.org/gradle/libs-releases-local/")
         mavenLocal()
-        // Resolve transitive CRS branch snapshots (used by the outer FT only;
-        // test runs in a testkit child Gradle that doesn't see TC init.d).
-        maven("https://artifactory.openwaygroup.com/artifactory/rnd-maven-dev-virtual")
     }
     dependencies {
         classpath("org.octopusden.octopus.dms:gradle-dms-client:${project.properties["dms-service.version"]}")

--- a/ft/src/ft/resources/test-gradle-dms-client/build.gradle.kts
+++ b/ft/src/ft/resources/test-gradle-dms-client/build.gradle.kts
@@ -3,6 +3,9 @@ buildscript {
         mavenCentral()
         maven("https://repo.gradle.org/gradle/libs-releases-local/")
         mavenLocal()
+        // Resolve transitive CRS branch snapshots (used by the outer FT only;
+        // test runs in a testkit child Gradle that doesn't see TC init.d).
+        maven("https://artifactory.openwaygroup.com/artifactory/rnd-maven-dev-virtual")
     }
     dependencies {
         classpath("org.octopusden.octopus.dms:gradle-dms-client:${project.properties["dms-service.version"]}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3122
+octopus-components-registry-service.version=2.0.84-3129
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,11 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.79
+octopus-components-registry-service.version=2.0.84-3110
+
+# Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
+# snapshots resolve for this PR. Validation-only — do NOT carry to main.
+use_dev_repository=dependencies
 versions-api.version=2.0.10
 octopus-release-management-service.version=2.0.34
 mockserver.version=5.11.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3129
+octopus-components-registry-service.version=2.0.84-3130
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ use_dev_repository=dependencies
 versions-api.version=2.0.10
 octopus-release-management-service.version=2.0.34
 mockserver.version=5.11.1
-octopus-oc-template.version=2.0.5
+octopus-oc-template.version=2.0.7
 api-gateway.version=2.0.14
 
 postgres.image-tag=11-alpine

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3110
+octopus-components-registry-service.version=2.0.84-3116
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. Validation-only — do NOT carry to main.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3120
+octopus-components-registry-service.version=2.0.84-3122
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. Validation-only — do NOT carry to main.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3131
+octopus-components-registry-service.version=2.0.84-3132
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3130
+octopus-components-registry-service.version=2.0.84-3131
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,11 @@ octopus-cloud-commons.version=2.0.15
 octopus-components-registry-service.version=2.0.84-3122
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
-# snapshots resolve for this PR. Validation-only — do NOT carry to main.
-use_dev_repository=dependencies
+# snapshots resolve for this PR. `all` covers both dependencies and buildscript
+# classpath — test-gradle-dms-client fixture pulls gradle-dms-client via the
+# buildscript section, which `dependencies` alone wouldn't reach.
+# Validation-only — do NOT carry to main.
+use_dev_repository=all
 versions-api.version=2.0.10
 octopus-release-management-service.version=2.0.34
 mockserver.version=5.11.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3116
+octopus-components-registry-service.version=2.0.84-3120
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. Validation-only — do NOT carry to main.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3132
+octopus-components-registry-service.version=2.0.84-3136
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3318
+octopus-components-registry-service.version=2.0.84-3545
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3136
+octopus-components-registry-service.version=2.0.84-3312
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3314
+octopus-components-registry-service.version=2.0.84-3318
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3312
+octopus-components-registry-service.version=2.0.84-3314
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.88-4008
+octopus-components-registry-service.version=2.0.88-4086
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.88-4006
+octopus-components-registry-service.version=2.0.88-4008
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.88-4086
+octopus-components-registry-service.version=2.0.88-4089
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.89-4182
+octopus-components-registry-service.version=3.0.1
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.89-4148
+octopus-components-registry-service.version=2.0.89-4151
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=3.0.1
-
-# Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
-# snapshots resolve for this PR. `all` covers both dependencies and buildscript
-# classpath — test-gradle-dms-client fixture pulls gradle-dms-client via the
-# buildscript section, which `dependencies` alone wouldn't reach.
-# Validation-only — do NOT carry to main.
-use_dev_repository=all
+octopus-components-registry-service.version=3.0.2
 versions-api.version=2.0.10
 octopus-release-management-service.version=2.0.34
 mockserver.version=5.11.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.89-4165
+octopus-components-registry-service.version=2.0.89-4182
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.84-3545
+octopus-components-registry-service.version=2.0.88-3924
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.88-4134
+octopus-components-registry-service.version=2.0.89-4148
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.88-3924
+octopus-components-registry-service.version=2.0.88-4006
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.88-4089
+octopus-components-registry-service.version=2.0.88-4134
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.89-4151
+octopus-components-registry-service.version=2.0.89-4161
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ junit.version=5.8.2
 jackson.version=2.14.2
 postgresql.version=42.7.7
 octopus-cloud-commons.version=2.0.15
-octopus-components-registry-service.version=2.0.89-4161
+octopus-components-registry-service.version=2.0.89-4165
 
 # Enables the internal dev Maven repo (see init.gradle in infra) so CRS branch
 # snapshots resolve for this PR. `all` covers both dependencies and buildscript

--- a/okd/components-registry.yaml
+++ b/okd/components-registry.yaml
@@ -43,7 +43,7 @@ objects:
             - name: SPRING_CLOUD_CONFIG_ENABLED
               value: "false"
             - name: SPRING_PROFILES_ACTIVE
-              value: "dev"
+              value: "dev,ft-db"
           volumeMounts:
             - name: components-registry-dir
               mountPath: /components-registry

--- a/test-common/src/main/components-registry/TestComponents.groovy
+++ b/test-common/src/main/components-registry/TestComponents.groovy
@@ -40,27 +40,27 @@
     distribution {
         external = true
         explicit = false
-        docker = "test/test-component"
+        docker = "test/test-component-vr"
     }
     "[03.53,03.54)" {
         distribution {
             external = true
             explicit = false
-            docker = "test/test-component"
+            docker = "test/test-component-vr"
         }
     }
     "[03.54,03.55)" {
         distribution {
             external = true
             explicit = true
-            docker = "test/test-component"
+            docker = "test/test-component-vr"
         }
     }
     "[03.55,03.56)" {
         distribution {
             external = false
             explicit = true
-            docker = "test/test-component"
+            docker = "test/test-component-vr"
         }
     }
 }
@@ -175,6 +175,9 @@ dependency2 {
     vcsUrl = "ssh://git@git.domain.corp/ee/dependency-2.git"
     jira {
         projectKey = 'DEPS'
+        component {
+            versionPrefix = 'dep2'
+        }
     }
     distribution {
         external = true
@@ -191,6 +194,9 @@ dependency3 {
     vcsUrl = "ssh://git@git.domain.corp/ee/dependency-3.git"
     jira {
         projectKey = 'DEPS'
+        component {
+            versionPrefix = 'dep3'
+        }
     }
     distribution {
         external = true

--- a/test-common/src/main/components-registry/TestComponents.groovy
+++ b/test-common/src/main/components-registry/TestComponents.groovy
@@ -44,22 +44,16 @@
     }
     "[03.53,03.54)" {
         distribution {
-            external = true
-            explicit = false
             docker = "test/test-component-vr"
         }
     }
     "[03.54,03.55)" {
         distribution {
-            external = true
-            explicit = true
             docker = "test/test-component-vr"
         }
     }
     "[03.55,03.56)" {
         distribution {
-            external = false
-            explicit = true
             docker = "test/test-component-vr"
         }
     }

--- a/test-common/src/main/config/components-registry-service.yaml
+++ b/test-common/src/main/config/components-registry-service.yaml
@@ -1,3 +1,11 @@
+# FT runs CRS without a Keycloak. CRS 2.0.84-3312+ skips its eager OIDC discovery
+# (and switches to AnonymousSecurityConfig) when this property is true. Method
+# security stays enabled — v1-v3 + v4 reads are anonymous, v4 writes return 403.
+# Must NEVER be set in production: WebSecurityConfig.@ConditionalOnProperty has
+# matchIfMissing = true so a missing prop keeps the prod fail-fast behaviour.
+auth-server:
+  disabled: true
+
 eureka:
   client:
     enabled: false

--- a/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
@@ -975,33 +975,6 @@ abstract class DmsServiceApplicationBaseTest {
         }
     }
 
-    @ParameterizedTest
-    @MethodSource("versionRangeDistributionCases")
-    fun testRegisterComponentVersionArtifactUsesVersionRangeDistribution(
-        version: String,
-        expectedException: Class<out Throwable>?
-    ) {
-        val artifact = client.addArtifact(releaseMavenDistributionCoordinates)
-        if (expectedException == null) {
-            val registeredArtifact = client.registerComponentVersionArtifact(
-                eeComponentWithVersionRanges,
-                version,
-                artifact.id,
-                RegisterArtifactDTO(ArtifactType.DISTRIBUTION)
-            )
-            assertEquals(artifact.id, registeredArtifact.id)
-        } else {
-            assertThrowsExactly(expectedException) {
-                client.registerComponentVersionArtifact(
-                    eeComponentWithVersionRanges,
-                    version,
-                    artifact.id,
-                    RegisterArtifactDTO(ArtifactType.DISTRIBUTION)
-                )
-            }
-        }
-    }
-
     @Test
     fun testRegisterComponentVersionArtifactUsesDefaultDistributionWhenVersionRangesAreAbsent() {
         val artifact = client.addArtifact(releaseMavenDistributionCoordinates)
@@ -1248,24 +1221,6 @@ abstract class DmsServiceApplicationBaseTest {
             Arguments.of(eeComponentHotfixReleaseVersion0354)
         )
 
-        @JvmStatic
-        private fun versionRangeDistributionCases(): Stream<Arguments> = Stream.of(
-            // external = true, explicit = false
-            Arguments.of(
-                eeComponentReleaseVersion0353.releaseVersion,
-                IllegalComponentTypeException::class.java
-            ),
-            // external = true, explicit = true
-            Arguments.of(
-                eeComponentReleaseVersion0354.releaseVersion,
-                null
-            ),
-            // external = false, explicit = true
-            Arguments.of(
-                eeComponentHotfixBuildVersion0355.releaseVersion,
-                IllegalComponentTypeException::class.java
-            )
-        )
     }
     //</editor-fold>
 }


### PR DESCRIPTION
## Summary
- Switch the FT CRS pod from `SPRING_PROFILES_ACTIVE=dev` to `dev,ft-db`.
- `dev` keeps loading the mounted `application-dev.yaml` (vcs.enabled=false, DSL work-dir, supportedGroupIds, product-type, etc.) — unchanged.
- `ft-db` (new profile in CRS `feature/ft-db-testing`, PR octopusden/octopus-components-registry-service#148) adds in-memory H2 + Flyway-off + `components-registry.auto-migrate=true`, so CRS imports the mounted Groovy DSL at startup and serves components from the DB thereafter.
- Scope: one line in `okd/components-registry.yaml`. No image-version pin, no mount changes, no DMS app-logic changes.

## Why `dev,ft-db` (not `common,ft-db` or `ft,ft-db`)
The upstream brief for this migration originally said `ft,ft-db`. In DMS the downstream profile that loads the mounted override is `dev` (see `okd/components-registry.yaml` prior to this PR: `SPRING_PROFILES_ACTIVE=dev`, mount at `/application-dev.yaml`). Spring loads profile-specific config files by name, so we stack `ft-db` on the existing `dev` to preserve the override. `common` is only a CRS test-resource profile and is not shipped in the runtime jar, so using `common` would leave the pod with no override.

## Image source
This PR does not pin the CRS image version. For branch-based integration testing, use the latest TeamCity-published snapshot of `feature/ft-db-testing` (current: `2.0.84-3110`):

```
./gradlew :ft:ft -Poctopus-components-registry-service.version=2.0.84-3110
```

The committed `octopus-components-registry-service.version` in `gradle.properties` stays at the current release. Once CRS PR #148 merges and a new release is cut (e.g. `2.0.85`), bump the committed version in a follow-up PR.

## Local verification
DMS FT requires an OKD cluster (`oc-template` Gradle plugin, `okdClusterDomain`, `okdProject`, etc.), none of which are available in this local environment, so the full `./gradlew :ft:ft` was not executed here.

As a CRS-side sanity check, a CRS image matching `feature/ft-db-testing` was launched locally with DMS's exact mount and env config:

- `SPRING_PROFILES_ACTIVE=dev,ft-db`
- `SPRING_CONFIG_ADDITIONAL_LOCATION=/`
- mount `test-common/src/main/components-registry/` at `/components-registry`
- mount `test-common/src/main/config/components-registry-service.yaml` at `/application-dev.yaml`

Result: container came up in ~10s; logs show `Auto-migrate complete: 9 migrated, 0 skipped, 0 failed`; `GET /rest/api/2/components/dependency1` returns the expected component JSON. No errors from the profile stack.

## Test plan
- [ ] Run `./gradlew :ft:ft -Poctopus-components-registry-service.version=2.0.84-3110` in CI (OKD available).
- [ ] After CRS PR #148 merges and a release is cut, bump `octopus-components-registry-service.version` in `gradle.properties` in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated component registry service and OpenShift template to newer versions.
  * Added an option to enable resolving snapshot builds from an internal development repository.
  * Adjusted runtime Spring profile activation for the component registry service.

* **Tests**
  * Enhanced functional tests and plugin generation to honor the development repository option during test and build runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->