### PR TITLE
Improve error message when deleting artifact from a published version

### DIFF
--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
@@ -290,9 +290,6 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         val buildVersion = releaseManagementService.findRelease(componentName, version, true)?.version ?: version
         componentRepository.lock(componentName.hashCode())
         componentVersionRepository.findByComponentNameAndVersion(componentName, buildVersion)?.let { componentVersion ->
-            if (componentVersion.published) {
-                throw VersionPublishedException("Version '$buildVersion' of component '$componentName' is published. Unable to delete artifact with ID '$artifactId' for the component version")
-            }
             componentVersionArtifactRepository.findByComponentVersionAndArtifactId(componentVersion, artifactId)?.let {
                 if (!dryRun) {
                     applicationEventPublisher.publishEvent(

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
@@ -290,6 +290,9 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         val buildVersion = releaseManagementService.findRelease(componentName, version, true)?.version ?: version
         componentRepository.lock(componentName.hashCode())
         componentVersionRepository.findByComponentNameAndVersion(componentName, buildVersion)?.let { componentVersion ->
+            if (componentVersion.published) {
+                throw VersionPublishedException("Version '$buildVersion' of component '$componentName' is published. Unable to delete artifact with ID '$artifactId' for the component version. To unpublish the version, use: PATCH /components/$componentName/versions/$buildVersion with body {\"published\": false}")
+            }
             componentVersionArtifactRepository.findByComponentVersionAndArtifactId(componentVersion, artifactId)?.let {
                 if (!dryRun) {
                     applicationEventPublisher.publishEvent(

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
@@ -266,7 +266,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
             componentVersionArtifact.toFullDTO(dockerRegistry)
         } else {
             if (componentVersion.published) {
-                throw VersionPublishedException("Version '${release.version}' of component '$componentName' is published. Unable to register '${registerArtifactDTO.type}' artifact with ID '$artifactId' for the component version")
+                throw VersionPublishedException("Version '${release.version}' of component '$componentName' is published. Unable to register '${registerArtifactDTO.type}' artifact with ID '$artifactId' for the component version. The version must first be unpublished")
             }
             componentVersionArtifactRepository.save(
                 ComponentVersionArtifact(
@@ -291,7 +291,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         componentRepository.lock(componentName.hashCode())
         componentVersionRepository.findByComponentNameAndVersion(componentName, buildVersion)?.let { componentVersion ->
             if (componentVersion.published) {
-                throw VersionPublishedException("Version '$buildVersion' of component '$componentName' is published. Unable to delete artifact with ID '$artifactId' for the component version. To unpublish the version, use: PATCH /components/$componentName/versions/$buildVersion with body {\"published\": false}")
+                throw VersionPublishedException("Version '$buildVersion' of component '$componentName' is published. Unable to delete artifact with ID '$artifactId' for the component version. The version must first be unpublished")
             }
             componentVersionArtifactRepository.findByComponentVersionAndArtifactId(componentVersion, artifactId)?.let {
                 if (!dryRun) {

--- a/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
@@ -727,7 +727,12 @@ abstract class DmsServiceApplicationBaseTest {
             )
         )
         dependencies.forEach { (componentName, version) ->
-            client.deleteComponentVersionArtifact(componentName, version, artifact.id)
+            assertThrowsExactly(VersionPublishedException::class.java) {
+                client.deleteComponentVersionArtifact(componentName, version, artifact.id)
+            }
+            assertThrowsExactly(VersionPublishedException::class.java) {
+                client.patchComponentVersion(componentName, version, PatchComponentVersionDTO(false))
+            }
         }
         assertEquals(
             ComponentVersionDTO(
@@ -743,6 +748,13 @@ abstract class DmsServiceApplicationBaseTest {
                 PatchComponentVersionDTO(false)
             )
         )
+        dependencies.forEach { (componentName, version) ->
+            assertThrowsExactly(VersionPublishedException::class.java) {
+                client.deleteComponentVersionArtifact(componentName, version, artifact.id)
+            }
+            client.patchComponentVersion(componentName, version, PatchComponentVersionDTO(false))
+            client.deleteComponentVersionArtifact(componentName, version, artifact.id)
+        }
     }
 
     @ParameterizedTest

--- a/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
@@ -727,12 +727,7 @@ abstract class DmsServiceApplicationBaseTest {
             )
         )
         dependencies.forEach { (componentName, version) ->
-            assertThrowsExactly(VersionPublishedException::class.java) {
-                client.deleteComponentVersionArtifact(componentName, version, artifact.id)
-            }
-            assertThrowsExactly(VersionPublishedException::class.java) {
-                client.patchComponentVersion(componentName, version, PatchComponentVersionDTO(false))
-            }
+            client.deleteComponentVersionArtifact(componentName, version, artifact.id)
         }
         assertEquals(
             ComponentVersionDTO(
@@ -748,13 +743,6 @@ abstract class DmsServiceApplicationBaseTest {
                 PatchComponentVersionDTO(false)
             )
         )
-        dependencies.forEach { (componentName, version) ->
-            assertThrowsExactly(VersionPublishedException::class.java) {
-                client.deleteComponentVersionArtifact(componentName, version, artifact.id)
-            }
-            client.patchComponentVersion(componentName, version, PatchComponentVersionDTO(false))
-            client.deleteComponentVersionArtifact(componentName, version, artifact.id)
-        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Refined the error message displayed when attempting to delete an artifact that belongs to a published version.

Previously, the message was unclear and did not provide sufficient context about why the action was not allowed. This update ensures the error message is more descriptive and helps users understand that artifacts from published versions cannot be deleted.