### PR TITLE
Add request and limit for each FT service

### DIFF
--- a/ft/build.gradle.kts
+++ b/ft/build.gradle.kts
@@ -102,6 +102,10 @@ ocTemplate{
                 "POSTGRES_USER" to project.properties["dms-postgres.user"] as String,
                 "POSTGRES_PASSWORD" to project.properties["dms-postgres.password"] as String,
                 "POSTGRES_STORAGE" to project.properties["dms-postgres.storage"] as String,
+                "CPU_REQUEST" to "50m",
+                "CPU_LIMIT" to "100m",
+                "MEMORY_REQUEST" to "64Mi",
+                "MEMORY_LIMIT" to "128Mi",
             )
         )
     }
@@ -116,6 +120,10 @@ ocTemplate{
                 "POSTGRES_USER" to project.properties["artifactory-postgres.user"] as String,
                 "POSTGRES_PASSWORD" to project.properties["artifactory-postgres.password"] as String,
                 "POSTGRES_STORAGE" to project.properties["artifactory-postgres.storage"] as String,
+                "CPU_REQUEST" to "20m",
+                "CPU_LIMIT" to "50m",
+                "MEMORY_REQUEST" to "128Mi",
+                "MEMORY_LIMIT" to "200Mi",
             )
         )
         dependsOn.set(listOf("dms-postgres"))

--- a/okd/api-gateway.yaml
+++ b/okd/api-gateway.yaml
@@ -22,6 +22,13 @@ objects:
       containers:
         - name: gateway
           image: ${OCTOPUS_GITHUB_DOCKER_REGISTRY}/octopusden/api-gateway:${API_GATEWAY_VERSION}
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "450Mi"
+            limits:
+              cpu: "500m"
+              memory: "600Mi"
           ports:
             - containerPort: 8765
               protocol: TCP

--- a/okd/artifactory.yaml
+++ b/okd/artifactory.yaml
@@ -76,7 +76,7 @@ objects:
               cpu: "250m"
               memory: "3Gi"
             limits:
-              cpu: "2000m"
+              cpu: "3000m"
               memory: "4Gi"
           ports:
             - containerPort: 8081

--- a/okd/artifactory.yaml
+++ b/okd/artifactory.yaml
@@ -76,7 +76,7 @@ objects:
               cpu: "250m"
               memory: "3Gi"
             limits:
-              cpu: "500m"
+              cpu: "2000m"
               memory: "4Gi"
           ports:
             - containerPort: 8081

--- a/okd/artifactory.yaml
+++ b/okd/artifactory.yaml
@@ -73,7 +73,11 @@ objects:
           image: releases-docker.jfrog.io/jfrog/artifactory-oss:${ARTIFACTORY_IMAGE_TAG}
           resources:
             requests:
+              cpu: "250m"
               memory: "3Gi"
+            limits:
+              cpu: "500m"
+              memory: "4Gi"
           ports:
             - containerPort: 8081
             - containerPort: 8082

--- a/okd/components-registry.yaml
+++ b/okd/components-registry.yaml
@@ -28,6 +28,13 @@ objects:
       containers:
         - name: comp-reg
           image: ${DOCKER_REGISTRY}/octopusden/components-registry-service:${COMPONENTS_REGISTRY_SERVICE_VERSION}
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "450Mi"
+            limits:
+              cpu: "400m"
+              memory: "600Mi"
           ports:
             - containerPort: 4567
               protocol: TCP

--- a/okd/dms-service.yaml
+++ b/okd/dms-service.yaml
@@ -22,6 +22,13 @@ objects:
       containers:
         - name: dms-service
           image: ${OCTOPUS_GITHUB_DOCKER_REGISTRY}/octopusden/dms-service:${DMS_SERVICE_VERSION}
+          resources:
+            requests:
+              cpu: "650m"
+              memory: "600Mi"
+            limits:
+              cpu: "1000m"
+              memory: "800Mi"
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/okd/mockserver.yaml
+++ b/okd/mockserver.yaml
@@ -15,6 +15,13 @@ objects:
       containers:
         - name: mockserver
           image: ${DOCKER_REGISTRY}/mockserver/mockserver:mockserver-${MOCK_SERVER_VERSION}
+          resources:
+            requests:
+              cpu: "550m"
+              memory: "300Mi"
+            limits:
+              cpu: "800m"
+              memory: "400Mi"
           ports:
             - containerPort: 1080
               protocol: TCP

--- a/okd/postgres.yaml
+++ b/okd/postgres.yaml
@@ -26,6 +26,13 @@ objects:
       containers:
         - name: postgres
           image: ${DOCKER_REGISTRY}/postgres:${POSTGRES_IMAGE_TAG}
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
           env:
             - name: POSTGRES_DB
               value: ${POSTGRES_DB}
@@ -92,4 +99,16 @@ parameters:
     required: true
   - name: DOCKER_REGISTRY
     description: Docker registry
+    required: true
+  - name: CPU_REQUEST
+    description: CPU request
+    required: true
+  - name: CPU_LIMIT
+    description: CPU limit
+    required: true
+  - name: MEMORY_REQUEST
+    description: Memory request
+    required: true
+  - name: MEMORY_LIMIT
+    description: Memory limit
     required: true

--- a/okd/release-management.yaml
+++ b/okd/release-management.yaml
@@ -22,6 +22,13 @@ objects:
       containers:
         - name: rm
           image: ${OCTOPUS_GITHUB_DOCKER_REGISTRY}/octopusden/release-management-service:${RELEASE_MANAGEMENT_SERVICE_VERSION}
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "350Mi"
+            limits:
+              cpu: "400m"
+              memory: "500Mi"
           ports:
             - containerPort: 8083
               protocol: TCP

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -138,6 +138,10 @@ ocTemplate{
                 "POSTGRES_USER" to project.properties["dms-postgres.user"] as String,
                 "POSTGRES_PASSWORD" to project.properties["dms-postgres.password"] as String,
                 "POSTGRES_STORAGE" to project.properties["dms-postgres.storage"] as String,
+                "CPU_REQUEST" to "50m",
+                "CPU_LIMIT" to "100m",
+                "MEMORY_REQUEST" to "64Mi",
+                "MEMORY_LIMIT" to "128Mi",
             )
         )
     }
@@ -151,7 +155,11 @@ ocTemplate{
                 "POSTGRES_DB" to project.properties["artifactory-postgres.db"] as String,
                 "POSTGRES_USER" to project.properties["artifactory-postgres.user"] as String,
                 "POSTGRES_PASSWORD" to project.properties["artifactory-postgres.password"] as String,
-                "POSTGRES_STORAGE" to project.properties["artifactory-postgres.storage"] as String
+                "POSTGRES_STORAGE" to project.properties["artifactory-postgres.storage"] as String,
+                "CPU_REQUEST" to "20m",
+                "CPU_LIMIT" to "50m",
+                "MEMORY_REQUEST" to "128Mi",
+                "MEMORY_LIMIT" to "200Mi",
             )
         )
         dependsOn.set(listOf("dms-postgres"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource constraints across multiple services (Postgres, API Gateway, Artifactory, Components Registry, DMS Service, MockServer, Release Management) by defining explicit CPU and memory requests and limits to enhance deployment resource management and scheduling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->