### PR TITLE
Fix getting information about the distribution section

### DIFF
--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/ComponentsRegistryService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/ComponentsRegistryService.kt
@@ -7,6 +7,7 @@ import org.octopusden.releng.versions.VersionNames
 
 interface ComponentsRegistryService {
     fun isComponentExists(component: String): Boolean
+    fun getExternalComponentVersion(component: String, version: String): ComponentDTO
     fun getExternalComponent(component: String): ComponentDTO
     fun getExternalComponents(filter: ComponentRequestFilter?): List<ComponentDTO>
     fun getDetailedComponentVersion(component: String, version: String): DetailedComponentVersion

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
@@ -93,7 +93,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         componentName: String, version: String
     ): List<ComponentVersionWithInfoDTO> {
         log.info("Get dependencies of version '$version' of component '$componentName'")
-        if (!getExternalExplicitComponent(componentName).solution) {
+        if (!getExternalExplicitComponentVersion(componentName, version).solution) {
             throw IllegalComponentTypeException("Component '$componentName' is not solution")
         }
         val release = releaseManagementService.getRelease(componentName, version, true)
@@ -112,7 +112,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         componentName: String, version: String, patchComponentVersionDTO: PatchComponentVersionDTO
     ): ComponentVersionDTO {
         log.info("${if (patchComponentVersionDTO.published) "Publish" else "Revoke"} version '$version' of component '$componentName'")
-        val component = getExternalExplicitComponent(componentName)
+        val component = getExternalExplicitComponentVersion(componentName, version)
         val release = releaseManagementService.getRelease(component.id, version, !patchComponentVersionDTO.published)
         componentRepository.lock(component.id.hashCode())
         val componentVersion = componentVersionRepository.getByComponentNameAndVersion(component.id, release.version)
@@ -128,7 +128,11 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
                 //      behaviour could be changed later - it may be required not to add dependencies artifacts in revoke event
                 val unpublishedDependencies = mutableListOf<BuildDTO>()
                 release.dependencies.forEach { dependencyBuild ->
-                    if (componentsRegistryService.getExternalComponent(dependencyBuild.component).explicit) {
+                    if (componentsRegistryService.getExternalComponentVersion(
+                            dependencyBuild.component,
+                            dependencyBuild.version
+                        ).explicit
+                    ) {
                         val dependencyComponentVersion = componentVersionRepository.findByComponentNameAndVersion(
                             dependencyBuild.component, dependencyBuild.version
                         )
@@ -149,7 +153,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
                 }
             } else if (!patchComponentVersionDTO.published) {
                 release.parents.filter {
-                    componentsRegistryService.getExternalComponent(it.component).solution &&
+                    componentsRegistryService.getExternalComponentVersion(it.component, it.version).solution &&
                             componentVersionRepository.findByComponentNameAndVersion(
                                 it.component,
                                 it.version
@@ -189,7 +193,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         componentName: String, version: String, type: ArtifactType?
     ): ArtifactsDTO {
         log.info("Get artifacts" + (type?.let { " with type '$it'" } ?: "") + " for version '$version' of component '$componentName'")
-        val component = getExternalExplicitComponent(componentName)
+        val component = getExternalExplicitComponentVersion(componentName, version)
         val release = releaseManagementService.getRelease(component.id, version, true)
         val componentVersion = componentVersionRepository.findByComponentNameAndVersion(component.id, release.version)
         val componentVersionArtifacts = if (componentVersion != null)
@@ -229,7 +233,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         registerArtifactDTO: RegisterArtifactDTO
     ): ArtifactFullDTO {
         log.info("Register '${registerArtifactDTO.type}' artifact with ID '$artifactId' for version '$version' of component '$componentName'")
-        getExternalExplicitComponent(componentName)
+        getExternalExplicitComponentVersion(componentName, version)
         val artifact = artifactRepository.findById(artifactId).orElseThrow {
             NotFoundException("Artifact with ID '$artifactId' is not found")
         }
@@ -309,12 +313,18 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
         }
     }
 
-    private fun getExternalExplicitComponent(componentName: String) =
-        componentsRegistryService.getExternalComponent(componentName).also {
-            if (!it.explicit) {
-                throw IllegalComponentTypeException("Component '$componentName' is not explicit")
-            }
+    private fun ComponentDTO.explicitOrBreak(): ComponentDTO {
+        if (!explicit) {
+            throw IllegalComponentTypeException("Component '$id' is not explicit")
         }
+        return this
+    }
+
+    private fun getExternalExplicitComponent(componentName: String) =
+        componentsRegistryService.getExternalComponent(componentName).explicitOrBreak()
+
+    private fun getExternalExplicitComponentVersion(componentName: String, version: String) =
+        componentsRegistryService.getExternalComponentVersion(componentName, version).explicitOrBreak()
 
     private fun getComponentVersions(
         componentName: String, minorVersions: List<String>, includeRc: Boolean
@@ -340,7 +350,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
     private fun getComponentVersionArtifactEntity(
         componentName: String, version: String, artifactId: Long
     ): ComponentVersionArtifact {
-        getExternalExplicitComponent(componentName)
+        getExternalExplicitComponentVersion(componentName, version)
         val buildVersion = releaseManagementService.getRelease(componentName, version, true).version
         return componentVersionArtifactRepository.getByComponentVersionComponentNameAndComponentVersionVersionAndArtifactId(
             componentName, buildVersion, artifactId

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentServiceImpl.kt
@@ -127,6 +127,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
                 //TODO: for now, EE dependencies artifacts are included in both publish and revoke events for solution components
                 //      behaviour could be changed later - it may be required not to add dependencies artifacts in revoke event
                 val unpublishedDependencies = mutableListOf<BuildDTO>()
+                // TODO: add a cache for component information.
                 release.dependencies.forEach { dependencyBuild ->
                     if (componentsRegistryService.getExternalComponentVersion(
                             dependencyBuild.component,
@@ -153,7 +154,7 @@ class ComponentServiceImpl( //TODO: move "start operation" logging to ComponentC
                 }
             } else if (!patchComponentVersionDTO.published) {
                 release.parents.filter {
-                    componentsRegistryService.getExternalComponentVersion(it.component, it.version).solution &&
+                    componentsRegistryService.getExternalComponent(it.component).solution &&
                             componentVersionRepository.findByComponentNameAndVersion(
                                 it.component,
                                 it.version

--- a/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentsRegistryServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/dms/service/impl/ComponentsRegistryServiceImpl.kt
@@ -36,12 +36,17 @@ class ComponentsRegistryServiceImpl(
         false
     }
 
-    override fun getExternalComponent(component: String) = client.getById(component).let {
-        if (it.distribution?.external != true) {
-            throw IllegalComponentTypeException("Component '$component' is not external")
+    private fun Component.externalOrBreak(): ComponentDTO {
+        if (distribution?.external != true) {
+            throw IllegalComponentTypeException("Component '${id}' is not external")
         }
-        it.toComponentDTO()
+        return toComponentDTO()
     }
+
+    override fun getExternalComponentVersion(component: String, version: String) =
+        client.getDetailedComponent(component, version).externalOrBreak()
+
+    override fun getExternalComponent(component: String) = client.getById(component).externalOrBreak()
 
     override fun getExternalComponents(filter: ComponentRequestFilter?) =
         client.getAllComponents(solution = filter?.solution).components

--- a/test-common/src/main/components-registry/TestComponents.groovy
+++ b/test-common/src/main/components-registry/TestComponents.groovy
@@ -21,6 +21,50 @@
     }
 }
 
+"ee-component-with-version-ranges" {
+    system = "CLASSIC"
+    componentDisplayName = "EE Component With Version Ranges"
+    componentOwner = "EE Component Owner"
+    releaseManager = "EE Component Release Manager"
+    groupId = "corp.domain"
+    vcsUrl = "ssh://git@git.domain.corp/ee/ee-component-with-version-ranges.git"
+    solution = true
+    jira {
+        projectKey = 'EEVR'
+        lineVersionFormat = '$major02.$minor02'
+        majorVersionFormat = '$major02.$minorC.$serviceC'
+        releaseVersionFormat = '$major02.$minor02.$service02.$fix02'
+        buildVersionFormat = '$major02.$minor02.$service02.$fix02-$build'
+        displayName = 'EE Component With Version Ranges'
+    }
+    distribution {
+        external = true
+        explicit = false
+        docker = "test/test-component"
+    }
+    "[03.53,03.54)" {
+        distribution {
+            external = true
+            explicit = false
+            docker = "test/test-component"
+        }
+    }
+    "[03.54,03.55)" {
+        distribution {
+            external = true
+            explicit = true
+            docker = "test/test-component"
+        }
+    }
+    "[03.55,03.56)" {
+        distribution {
+            external = false
+            explicit = true
+            docker = "test/test-component"
+        }
+    }
+}
+
 "ee-client-specific-component" {
     system = "CLASSIC"
     componentDisplayName = "EE Client Specific Component"

--- a/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
@@ -975,6 +975,45 @@ abstract class DmsServiceApplicationBaseTest {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("versionRangeDistributionCases")
+    fun testRegisterComponentVersionArtifactUsesVersionRangeDistribution(
+        version: String,
+        expectedException: Class<out Throwable>?
+    ) {
+        val artifact = client.addArtifact(releaseMavenDistributionCoordinates)
+        if (expectedException == null) {
+            val registeredArtifact = client.registerComponentVersionArtifact(
+                eeComponentWithVersionRanges,
+                version,
+                artifact.id,
+                RegisterArtifactDTO(ArtifactType.DISTRIBUTION)
+            )
+            assertEquals(artifact.id, registeredArtifact.id)
+        } else {
+            assertThrowsExactly(expectedException) {
+                client.registerComponentVersionArtifact(
+                    eeComponentWithVersionRanges,
+                    version,
+                    artifact.id,
+                    RegisterArtifactDTO(ArtifactType.DISTRIBUTION)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testRegisterComponentVersionArtifactUsesDefaultDistributionWhenVersionRangesAreAbsent() {
+        val artifact = client.addArtifact(releaseMavenDistributionCoordinates)
+        val registeredArtifact = client.registerComponentVersionArtifact(
+            eeComponent,
+            eeComponentReleaseVersion0354.releaseVersion,
+            artifact.id,
+            RegisterArtifactDTO(ArtifactType.DISTRIBUTION)
+        )
+        assertEquals(artifact.id, registeredArtifact.id)
+    }
+
     //<editor-fold defaultstate="collapsed" desc="Test Data">
     companion object {
         data class Version(val minorVersion: String, val buildVersion: String, val releaseVersion: String)
@@ -982,6 +1021,7 @@ abstract class DmsServiceApplicationBaseTest {
         const val ANY_VERSION = "ANY_VERSION"
         const val eeComponent = "ee-component"
         const val eeClientSpecificComponent = "ee-client-specific-component"
+        const val eeComponentWithVersionRanges = "ee-component-with-version-ranges"
 
         val eeComponentReleaseVersion0353 = Version("03.53.31", "03.53.30.31-1", "03.53.30.31")
         val eeComponentBuildVersion0353 = Version("03.53.31", "03.53.30.42-1", "03.53.30.42")
@@ -1206,6 +1246,25 @@ abstract class DmsServiceApplicationBaseTest {
         private fun testGetComponentVersionDependencies(): Stream<Arguments> = Stream.of(
             Arguments.of(eeComponentReleaseVersion0354),
             Arguments.of(eeComponentHotfixReleaseVersion0354)
+        )
+
+        @JvmStatic
+        private fun versionRangeDistributionCases(): Stream<Arguments> = Stream.of(
+            // external = true, explicit = false
+            Arguments.of(
+                eeComponentReleaseVersion0353.releaseVersion,
+                IllegalComponentTypeException::class.java
+            ),
+            // external = true, explicit = true
+            Arguments.of(
+                eeComponentReleaseVersion0354.releaseVersion,
+                null
+            ),
+            // external = false, explicit = true
+            Arguments.of(
+                eeComponentHotfixBuildVersion0355.releaseVersion,
+                IllegalComponentTypeException::class.java
+            )
         )
     }
     //</editor-fold>

--- a/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/dms/DmsServiceApplicationBaseTest.kt
@@ -758,10 +758,10 @@ abstract class DmsServiceApplicationBaseTest {
     }
 
     @ParameterizedTest
-    @MethodSource("nonEEComponents")
-    fun testPatchComponentVersionForNonEEComponent(component: String, exception: Class<out DMSException>) {
+    @MethodSource("nonEEComponentsVersioned")
+    fun testPatchComponentVersionForNonEEComponent(component: String, version: String, exception: Class<out DMSException>) {
         assertThrowsExactly(exception) {
-            client.patchComponentVersion(component, ANY_VERSION, PatchComponentVersionDTO(true))
+            client.patchComponentVersion(component, version, PatchComponentVersionDTO(true))
         }
     }
 
@@ -800,7 +800,7 @@ abstract class DmsServiceApplicationBaseTest {
         )
         assertThrowsExactly(IllegalComponentTypeException::class.java) {
             client.getComponentVersionDependencies(
-                eeClientSpecificComponent, ANY_VERSION
+                eeClientSpecificComponent, eeComponentReleaseVersion0353.buildVersion
             )
         }
     }
@@ -893,13 +893,13 @@ abstract class DmsServiceApplicationBaseTest {
     }
 
     @ParameterizedTest
-    @MethodSource("nonEEComponents")
-    fun testRegisterArtifactForNonEEComponent(component: String, exception: Class<out DMSException>) {
+    @MethodSource("nonEEComponentsVersioned")
+    fun testRegisterArtifactForNonEEComponent(component: String, version: String, exception: Class<out DMSException>) {
         val artifact = client.addArtifact(releaseMavenDistributionCoordinates)
         assertThrowsExactly(exception) {
             client.registerComponentVersionArtifact(
                 component,
-                ANY_VERSION,
+                version,
                 artifact.id,
                 RegisterArtifactDTO(ArtifactType.DISTRIBUTION)
             )
@@ -1072,6 +1072,14 @@ abstract class DmsServiceApplicationBaseTest {
             Arguments.of("ei-component", IllegalComponentTypeException::class.java),
             Arguments.of("ii-component", IllegalComponentTypeException::class.java),
             Arguments.of("no-component", NotFoundException::class.java)
+        )
+
+        @JvmStatic
+        private fun nonEEComponentsVersioned(): Stream<Arguments> = Stream.of(
+            Arguments.of("ie-component", "1.0.1", IllegalComponentTypeException::class.java),
+            Arguments.of("ei-component", "1.0.2", IllegalComponentTypeException::class.java),
+            Arguments.of("ii-component", "1.0.3", IllegalComponentTypeException::class.java),
+            Arguments.of("no-component", "1.0.4", NotFoundException::class.java)
         )
 
         @JvmStatic

--- a/test-common/src/main/mockserver/builds.json
+++ b/test-common/src/main/mockserver/builds.json
@@ -327,5 +327,35 @@
     "dependencies": [],
     "commits": [],
     "statusHistory": {}
+  },
+  {
+    "component": "ee-component-with-version-ranges",
+    "status": "RELEASE",
+    "version": "03.53.30.31-1",
+    "release_version": "03.53.30.31",
+    "parents": [],
+    "dependencies": [],
+    "commits": [],
+    "statusHistory": {}
+  },
+  {
+    "component": "ee-component-with-version-ranges",
+    "status": "RELEASE",
+    "version": "03.54.30.64-1",
+    "release_version": "03.54.30.64",
+    "parents": [],
+    "dependencies": [],
+    "commits": [],
+    "statusHistory": {}
+  },
+  {
+    "component": "ee-component-with-version-ranges",
+    "status": "RELEASE",
+    "version": "03.55.30.63-1",
+    "release_version": "03.55.30.63",
+    "parents": [],
+    "dependencies": [],
+    "commits": [],
+    "statusHistory": {}
   }
 ]

--- a/test-common/src/main/resources/components.json
+++ b/test-common/src/main/resources/components.json
@@ -66,6 +66,19 @@
       }
     },
     {
+      "id": "ee-component-with-version-ranges",
+      "name": "EE Component With Version Ranges",
+      "solution": true,
+      "explicit": false,
+      "clientCode": null,
+      "parentComponent": null,
+      "securityGroups": {
+        "read": [
+          "Production Security"
+        ]
+      }
+    },
+    {
       "id": "ie-component",
       "name": "IE Component",
       "solution": false,


### PR DESCRIPTION
Problem.
We have a component X. Until a certain point, it had the parameters `external=true` and `explicit=false`, and later `explicit` was changed to `true`.
However, when calling the `/rest/api/1/components/{componentKey}` endpoint, components-registry returns the first matching `distribution` configuration. Because of this, we get an incorrect value for the `explicit` flag and, as a result, are unable to upload artifacts.
If we retrieve component information by its version, we get the correct data in the `distribution` section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve external components for a specific version.

* **Improvements**
  * Validation and distribution checks now operate at the component-version level for more precise behavior.

* **Tests**
  * Added version-specific tests and coverage for version-range distribution scenarios.

* **Test Data**
  * Added test component entries and mock build records to exercise version-range behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->